### PR TITLE
Fix build tags for mips big-endian

### DIFF
--- a/xxhash_safe.go
+++ b/xxhash_safe.go
@@ -1,4 +1,4 @@
-// +build appengine safe ppc64le ppc64be mipsle mipsbe
+// +build appengine safe ppc64le ppc64be mipsle mips
 
 package xxhash
 

--- a/xxhash_unsafe.go
+++ b/xxhash_unsafe.go
@@ -3,7 +3,7 @@
 // +build !ppc64le
 // +build !mipsle
 // +build !ppc64be
-// +build !mipsbe
+// +build !mips
 
 package xxhash
 


### PR DESCRIPTION
The GOARCH value for big-endian 32-bit MIPS is 'mips'. This changes the build tag from `mipsbe` to `mips`.
```
  $ go tool dist list | grep mips
  linux/mips
  linux/mips64
  linux/mips64le
  linux/mipsle
```
The change fixes this build issue.
```
  $ GOOS=linux GOARCH=mips go build
  ./xxhash_unsafe.go:24:23: type [2147483647]byte larger than address space
  ./xxhash_unsafe.go:33:20: type [2147483647]byte larger than address space
  ./xxhash_unsafe.go:43:23: type [2147483647]byte larger than address space
  ./xxhash_unsafe.go:51:20: type [2147483647]byte larger than address space
```