### PR TITLE
Implement encoding.Binary(Un)Marshaler interfaces for XXHash32 and XX…

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ Fnv64Short-8                  74.7ns ± 8%
 
 ## License
 
-This project is released under the Apache v2. licence. See [LICENCE](LICENCE) for more details.
+This project is released under the Apache v2. licence. See [LICENSE](LICENSE) for more details.

--- a/xxhash_unsafe.go
+++ b/xxhash_unsafe.go
@@ -58,10 +58,9 @@ func checksum64(in []byte, seed uint64) uint64 {
 		wordsLen = len(in) >> 3
 		words    = ((*[maxInt32 / 8]uint64)(unsafe.Pointer(&in[0])))[:wordsLen:wordsLen]
 
-		h uint64 = prime64x5
-
 		v1, v2, v3, v4 = resetVs64(seed)
 
+		h uint64
 		i int
 	)
 


### PR DESCRIPTION
All standard hashes implement `Binary(Un)Marshaler` interface: https://golang.org/src/hash/marshal_test.go, so why not `OneOfOne/xxhash` :)

(If this gets accepted and merged I would appreciate bumping version of the package with this patch)