### PR TITLE
allocate the memory of XXHash object on stack

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/wanghaao/xxhash
+module github.com/OneOfOne/xxhash
 
 go 1.11

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/OneOfOne/xxhash
+module github.com/wanghaao/xxhash
 
 go 1.11

--- a/xxhash.go
+++ b/xxhash.go
@@ -57,6 +57,15 @@ func XXHash32Val(in *[]byte, seed uint32) uint32 {
 	return xx.Sum32()
 }
 
+func XXHash64Val(in *[]byte, seed uint64) uint64 {
+	xx := &XXHash64{
+		seed: seed,
+	}
+	xx.Reset()
+	_, _ = xx.Write(*in)
+	return xx.Sum64()
+}
+
 type XXHash32 struct {
 	mem            [16]byte
 	ln, memIdx     int32

--- a/xxhash.go
+++ b/xxhash.go
@@ -48,6 +48,15 @@ func ChecksumString32(s string) uint32 {
 	return ChecksumString32S(s, 0)
 }
 
+func XXHash32Val(in *[]byte, seed uint32) uint32 {
+	xx := &XXHash32{
+		seed: seed,
+	}
+	xx.Reset()
+	_, _ = xx.Write(*in)
+	return xx.Sum32()
+}
+
 type XXHash32 struct {
 	mem            [16]byte
 	ln, memIdx     int32


### PR DESCRIPTION
In the case of frequently calculating hash values, it performs better.